### PR TITLE
fix: disable SSL for grimmory init-db mariadb client

### DIFF
--- a/cluster/apps/books/grimmory/app/helmrelease.yaml
+++ b/cluster/apps/books/grimmory/app/helmrelease.yaml
@@ -38,11 +38,11 @@ spec:
             command: ["bash", "-c"]
             args:
               - |
-                until mariadb -h mariadb.data.svc -u root -p"$MYSQL_ROOT_PASSWORD" -e 'SELECT 1'; do
+                until mariadb --ssl=false -h mariadb.data.svc -u root -p"$MYSQL_ROOT_PASSWORD" -e 'SELECT 1'; do
                   echo "Waiting for MariaDB..."
                   sleep 3
                 done
-                mariadb -h mariadb.data.svc -u root -p"$MYSQL_ROOT_PASSWORD" -e "
+                mariadb --ssl=false -h mariadb.data.svc -u root -p"$MYSQL_ROOT_PASSWORD" -e "
                   CREATE DATABASE IF NOT EXISTS grimmory CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';
                   CREATE USER IF NOT EXISTS 'grimmory'@'%' IDENTIFIED BY '$DATABASE_PASSWORD';
                   GRANT ALL PRIVILEGES ON grimmory.* TO 'grimmory'@'%';


### PR DESCRIPTION
The `mariadb:11.4.5` client image enforces SSL by default. The MariaDB server at `mariadb.data.svc` does not have SSL configured, causing every init container connection attempt to fail with `SSL is required, but the server does not support it`.

Fix: added `--ssl=false` to both `mariadb` client invocations in the init-db container.